### PR TITLE
Update documentation for NinjaOne FedRamp support and API examples

### DIFF
--- a/docs/ninjaone/development/index.mdx
+++ b/docs/ninjaone/development/index.mdx
@@ -115,6 +115,54 @@ Run all phases:
 pwsh -File .\DevOps\Help\Orchestrate-HelpGeneration.ps1 -Phase All
 ```
 
+## Full Request Example Generation
+
+The full request example generator injects a dedicated help example for POST/PUT/PATCH cmdlets that accept request bodies. It reads the OpenAPI YAML (downloaded by default) and inserts a help block between the explicit markers shown below. Existing examples remain untouched.
+
+It requires a `ConvertFrom-Yaml` implementation (install either `powershell-yaml` or `Yayaml`).
+
+```text
+# FULL REQUEST EXAMPLE (AUTO-GENERATED) - BEGIN
+# FULL REQUEST EXAMPLE (AUTO-GENERATED) - END
+```
+
+Default run (downloads the OpenAPI YAML from the EU tenant):
+
+```powershell
+pwsh -File .\DevOps\Help\Generate-FullRequestExamples.ps1
+```
+
+Point at a local OpenAPI YAML file:
+
+```powershell
+pwsh -File .\DevOps\Help\Generate-FullRequestExamples.ps1 -YamlPath C:\path\to\NinjaRMM-API-v2.yaml
+```
+
+Target a single endpoint path:
+
+```powershell
+pwsh -File .\DevOps\Help\Generate-FullRequestExamples.ps1 -EndpointPath /v2/user/end-users
+```
+
+Target a specific cmdlet:
+
+```powershell
+pwsh -File .\DevOps\Help\Generate-FullRequestExamples.ps1 -CommandName New-NinjaOneEndUser
+```
+
+What it does:
+
+- Downloads or loads the OpenAPI YAML and parses request body schemas.
+- Builds a minimal example object from the schema (first option for oneOf/anyOf/allOf).
+- Updates only the marked example block in comment-based help.
+- Inserts the example before the .OUTPUTS section if no block exists.
+
+Common parameters:
+
+- `-BaseUrl` defaults to `https://eu.ninjarmm.com`.
+- `-SourcePath` defaults to `Source\Public`.
+- `-EndpointPath` and `-CommandName` filter the scope.
+
 ## Docs Generation
 
 Regenerate the short name map and update docs output:

--- a/docs/ninjaone/index.mdx
+++ b/docs/ninjaone/index.mdx
@@ -147,10 +147,4 @@ This will return a list of all devices in NinjaOne. For more detailed examples o
 
 ## Known Issues
 
-Many NinjaOne API endpoints require the use of a user's context. If you attempt to use these endpoints without interactive authentication you will receive an error similar to the following:
-
-> Line |
->   28 |          throw ('This function is not available when using client_cred …
->      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
->      | This function is not available when using client_credentials authentication. If this is unexpected
->      | please report this to api@ninjarmm.com.
+As of 2.3.0 the NinjaOne FedRamp instance is supported however this runs on an older version of NinjaOne and therefore some endpoints may not work as expected. NinjaOne do not version their API or API spec making it difficult to track which endpoints are supported in which instances.


### PR DESCRIPTION
This pull request updates the documentation for NinjaOne development and usage, focusing on clarifying known issues and introducing a new feature for generating full request examples. The most notable addition is a detailed explanation of the full request example generator, which provides automated help examples for cmdlets that accept request bodies.

Enhancements to documentation:

* Added a new section describing the full request example generator, including usage instructions, configuration options, and its behavior for POST/PUT/PATCH cmdlets in `docs/ninjaone/development/index.mdx`.

Clarification of known issues:

* Updated the known issues section in `docs/ninjaone/index.mdx` to clarify support for the NinjaOne FedRamp instance and highlight challenges due to lack of API versioning, replacing a previous authentication error example.